### PR TITLE
Fix: find parent node error

### DIFF
--- a/src/org-to-ast.ts
+++ b/src/org-to-ast.ts
@@ -10,7 +10,9 @@ export function parse(org: string): any {
   const src = new StructuredSource(org);
   traverse(ast).forEach(function (node: TxtNode) {
     if (this.notLeaf) {
-      delete node.parent;
+      // If exist timestamp on AST, textlint try to find parent node, and fail.
+      // TypeError: Cannot redefine property: parent
+      delete node.timestamp;
 
       // AST node has type and position
       if (node.type && node.position) {

--- a/test/fixtures/lint-error.org
+++ b/test/fixtures/lint-error.org
@@ -23,3 +23,11 @@ aaaaa,aaaaa,aaaaa,aaaaa,aaaaa,aaaaa
 - aaaaa,aaaaa,aaaaa,aaaaa,aaaaa,aaaaa
 
 # aaaaa,aaaaa,aaaaa,aaaaa,aaaaa,aaaaa
+
+** Check
+CLOSED: [2021-09-10 Fri 17:49]
+# If exist timestamp on AST, textlint try to find parent node, and fail.
+# TypeError: Cannot redefine property: parent
+
+** TODO aaaaa,aaaaa,aaaaa,aaaaa,aaaaa,aaaaa
+** DONE aaaaa,aaaaa,aaaaa,aaaaa,aaaaa,aaaaa


### PR DESCRIPTION
```
TypeError: Cannot redefine property: parent
at /home/kijima/Project/textlint-plugin-org/test/fixtures/lint-error.org
      at Function.defineProperty (<anonymous>)
      at Controller.enter (node_modules/@textlint/kernel/src/task/textlint-core-task.ts:156:24)
      at Controller.__execute (node_modules/@textlint/ast-traverse/src/index.ts:51:31)
      at Controller.traverse (node_modules/@textlint/ast-traverse/src/index.ts:132:28)
      at TextLintCoreTask.startTraverser (node_modules/@textlint/kernel/src/task/textlint-core-task.ts:153:28)
      at TextLintCoreTask.start (node_modules/@textlint/kernel/src/task/linter-task.ts:43:14)
      at /home/kijima/Project/textlint-plugin-org/node_modules/@textlint/kernel/src/task/task-runner.ts:28:18
      at new Promise (<anonymous>)
      at Function.process (node_modules/@textlint/kernel/src/task/task-runner.ts:16:16)
      at LinterProcessor.process (node_modules/@textlint/kernel/src/linter/linter-processor.ts:55:27)
      at TextlintKernel._parallelProcess (node_modules/@textlint/kernel/src/textlint-kernel.ts:170:14)
      at /home/kijima/Project/textlint-plugin-org/node_modules/@textlint/kernel/src/textlint-kernel.ts:85:25
```