### PR TITLE
fix: missing runtime dependencies (@textlint/ast-node-types and traverse)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,12 +5,14 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "textlint-plugin-org",
             "version": "0.3.3",
             "license": "GPLv3",
             "dependencies": {
                 "@types/date-fns": "^2.6.0",
                 "orga": "2.4.9",
-                "structured-source": "^3.0.2"
+                "structured-source": "^3.0.2",
+                "traverse": "^0.6.6"
             },
             "devDependencies": {
                 "@textlint/ast-tester": "^12.0.0",
@@ -25,7 +27,6 @@
                 "mocha": "^10.0.0",
                 "power-assert": "^1.6.1",
                 "textlint-rule-max-comma": "^2.0.2",
-                "traverse": "^0.6.6",
                 "ts-node": "^10.0.0",
                 "ts-node-test-register": "^10.0.0",
                 "typescript": "^4.3.2"
@@ -4152,8 +4153,7 @@
         "node_modules/traverse": {
             "version": "0.6.6",
             "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
-            "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
-            "dev": true
+            "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
         },
         "node_modules/trough": {
             "version": "1.0.5",
@@ -7741,8 +7741,7 @@
         "traverse": {
             "version": "0.6.6",
             "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
-            "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
-            "dev": true
+            "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
         },
         "trough": {
             "version": "1.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "0.3.3",
             "license": "GPLv3",
             "dependencies": {
+                "@textlint/ast-node-types": "^12.2.2",
                 "@types/date-fns": "^2.6.0",
                 "orga": "2.4.9",
                 "structured-source": "^3.0.2",
@@ -326,8 +327,7 @@
         "node_modules/@textlint/ast-node-types": {
             "version": "12.2.2",
             "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-12.2.2.tgz",
-            "integrity": "sha512-VQAXUSGdmEajHXrMxeM9ZTS8UBJSVB0ghJFHpFfqYKlcDsjIqClSmTprY6521HoCoSLoUIGBxTC3jQyUMJFIWw==",
-            "dev": true
+            "integrity": "sha512-VQAXUSGdmEajHXrMxeM9ZTS8UBJSVB0ghJFHpFfqYKlcDsjIqClSmTprY6521HoCoSLoUIGBxTC3jQyUMJFIWw=="
         },
         "node_modules/@textlint/ast-tester": {
             "version": "12.2.2",
@@ -4885,8 +4885,7 @@
         "@textlint/ast-node-types": {
             "version": "12.2.2",
             "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-12.2.2.tgz",
-            "integrity": "sha512-VQAXUSGdmEajHXrMxeM9ZTS8UBJSVB0ghJFHpFfqYKlcDsjIqClSmTprY6521HoCoSLoUIGBxTC3jQyUMJFIWw==",
-            "dev": true
+            "integrity": "sha512-VQAXUSGdmEajHXrMxeM9ZTS8UBJSVB0ghJFHpFfqYKlcDsjIqClSmTprY6521HoCoSLoUIGBxTC3jQyUMJFIWw=="
         },
         "@textlint/ast-tester": {
             "version": "12.2.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "dependencies": {
         "@types/date-fns": "^2.6.0",
         "orga": "2.4.9",
-        "structured-source": "^3.0.2"
+        "structured-source": "^3.0.2",
+        "traverse": "^0.6.6"
     },
     "devDependencies": {
         "@textlint/ast-tester": "^12.0.0",
@@ -45,7 +46,6 @@
         "mocha": "^10.0.0",
         "power-assert": "^1.6.1",
         "textlint-rule-max-comma": "^2.0.2",
-        "traverse": "^0.6.6",
         "ts-node": "^10.0.0",
         "ts-node-test-register": "^10.0.0",
         "typescript": "^4.3.2"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
         "lint": "npx eslint src/**/*.ts"
     },
     "dependencies": {
+        "@textlint/ast-node-types": "^12.2.2",
         "@types/date-fns": "^2.6.0",
         "orga": "2.4.9",
         "structured-source": "^3.0.2",


### PR DESCRIPTION
This should fix #100.

`traverse` is required at runtime, by [`org-to-ast.ts`](https://github.com/kijimaD/textlint-plugin-org/blob/main/src/org-to-ast.ts#L2), and yet is declared as a devdependency.

`@textlint/ast-node-types` is also required at runtime (by [`org-to-ast.ts`](https://github.com/kijimaD/textlint-plugin-org/blob/main/src/org-to-ast.ts#L5) and [`mapping.ts`](https://github.com/kijimaD/textlint-plugin-org/blob/main/src/mapping.ts#L1), but is only pulled in indirectly as a devdependency.

As a result,

    npm install textlint-plugin-org

doesn't pull either of them in, leading to the error seen in #100.

This PR fixes the missing dependencies.